### PR TITLE
1.4.7 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Plug & Play: extract and start (Ollama + Python required)
 
 ## Installation
 
+**Release dependency note:**  
+If you install from a GitHub Release package, please use the latest `requirements.txt` from this repository when setting up dependencies.  
+Release packages are updated regularly, and they are also updated when critical fixes are included.
+
 **Windows:**
 1. Download [Crawllama v1.4.7 Preview Release](https://github.com/arn-c0de/Crawllama/releases/tag/v1.4.7-preview)
 2. Extract to any folder (e.g., `C:\Crawllama`)

--- a/core/agent/agent.py
+++ b/core/agent/agent.py
@@ -1122,9 +1122,12 @@ Content:
         # Detect base64-embedded prompt injection strings
         for token in re.findall(r"\b[A-Za-z0-9+/]{20,}={0,2}\b", query):
             padded = token + "=" * ((4 - len(token) % 4) % 4)
+            decoded = ""
             try:
                 decoded = base64.b64decode(padded, validate=True).decode("utf-8", errors="ignore")
-            except Exception:
+            except Exception as exc:
+                logger.debug("Skipping undecodable base64 token in query injection scan: %s", exc)
+            if not decoded:
                 continue
             if _matches_obfuscated_patterns(decoded):
                 logger.warning("Detected base64-obfuscated prompt injection pattern")

--- a/core/cache.py
+++ b/core/cache.py
@@ -47,7 +47,8 @@ class CacheManager:
         Returns:
             MD5 hash of identifier
         """
-        return hashlib.md5(identifier.encode()).hexdigest()
+        # Non-cryptographic usage: stable, compact cache filename derivation.
+        return hashlib.md5(identifier.encode("utf-8"), usedforsecurity=False).hexdigest()
 
     def get(self, key: str) -> Optional[Dict[str, Any]]:
         """

--- a/core/health/result_parser.py
+++ b/core/health/result_parser.py
@@ -49,7 +49,7 @@ class ResultParser:
                 'errors': 0,
                 'timeout': 0,
                 'duration': 0,
-                'pass_rate': 0,
+                'pass_rate': 0,  # nosec B105 - default summary metric, not credentials
                 'status': 'idle'
             }
 

--- a/core/health/widgets/status_card.py
+++ b/core/health/widgets/status_card.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
         'passed': 12,
         'failed': 2,
         'skipped': 1,
-        'pass_rate': 80.0,
+        'pass_rate': 80.0,  # nosec B105 - numeric UI demo metric, not credentials
         'duration': 15.8
     }
 

--- a/core/osint/domain_intel.py
+++ b/core/osint/domain_intel.py
@@ -364,12 +364,16 @@ class DomainIntelligence:
             # Use ip-api.com free API
             url = f"http://ip-api.com/json/{ip}?fields=status,message,country,countryCode,region,regionName,city,lat,lon,timezone,isp,org,as"
 
-            # Validate URL scheme before opening
+            # Validate URL scheme and host before opening
             parsed_url = urlparse(url)
             if parsed_url.scheme not in ("http", "https"):
                 logger.warning(f"Blocked attempt to open URL with unsupported scheme: {parsed_url.scheme}")
                 raise ValueError("Unsupported URL scheme for geolocation API.")
+            if parsed_url.netloc != "ip-api.com":
+                logger.warning(f"Blocked geolocation API host: {parsed_url.netloc}")
+                raise ValueError("Unsupported geolocation API host.")
 
+            # nosec B310: URL is constructed in-code and restricted to allowed scheme/host above.
             with urllib.request.urlopen(url, timeout=5) as response:
                 data = json.loads(response.read().decode('utf-8'))
 

--- a/core/osint/sources/manager.py
+++ b/core/osint/sources/manager.py
@@ -98,8 +98,8 @@ class BreachManager:
             if hasattr(source, "last_paste_count"):
                 try:
                     paste_count += int(getattr(source, "last_paste_count") or 0)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("Invalid last_paste_count for source '%s': %s", source.name, exc)
 
             self._log_source_query(source.name, email, result_count, success)
 

--- a/tools/page_reader.py
+++ b/tools/page_reader.py
@@ -77,9 +77,12 @@ def _contains_obfuscated_prompt_injection(content: str) -> bool:
     # Try decoding long base64-like blobs and inspect decoded content
     for token in re.findall(r"\b[A-Za-z0-9+/]{20,}={0,2}\b", content):
         padded = token + "=" * ((4 - len(token) % 4) % 4)
+        decoded = ""
         try:
             decoded = base64.b64decode(padded, validate=True).decode("utf-8", errors="ignore")
-        except Exception:
+        except Exception as exc:
+            logger.debug("Skipping undecodable base64 token during prompt-injection scan: %s", exc)
+        if not decoded:
             continue
         if _matches_compact_injection_patterns(_normalize_for_prompt_injection_detection(decoded)):
             return True
@@ -158,15 +161,16 @@ def sanitize_crawled_content_for_llm(content: str, max_length: int = 8000) -> st
             if decoded == content:
                 break  # No more decoding needed
             content = decoded
-        except Exception:
+        except Exception as exc:
+            logger.debug("URL decoding failed during content sanitization: %s", exc)
             break  # Decoding failed, continue with original
 
     # 1b. Unicode normalization to prevent homograph attacks
     # Example: "ⅰgnore" (unicode) -> "ignore" (ascii)
     try:
         content = unicodedata.normalize('NFKC', content)
-    except Exception:
-        pass  # Normalization failed, continue with original
+    except Exception as exc:
+        logger.debug("Unicode normalization failed during content sanitization: %s", exc)
 
     # 2. Remove dangerous prompt injection patterns (now more effective after decoding)
     dangerous_patterns = [

--- a/utils/cli_input.py
+++ b/utils/cli_input.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import atexit
+import logging
 from pathlib import Path
 from typing import Optional
 
 _HISTORY_PATH = Path("data") / ".cli_history"
 _HISTORY_LEN = 1000
+logger = logging.getLogger("crawllama")
 
 
 try:
@@ -35,16 +37,16 @@ except Exception:  # pragma: no cover - fallback for environments without prompt
         try:
             if _HISTORY_PATH.exists():
                 readline.read_history_file(str(_HISTORY_PATH))
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Unable to load CLI history file: %s", exc)
 
         readline.set_history_length(_HISTORY_LEN)
 
         def _save_history() -> None:
             try:
                 readline.write_history_file(str(_HISTORY_PATH))
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Unable to persist CLI history file: %s", exc)
 
         atexit.register(_save_history)
 

--- a/utils/safe_fetch.py
+++ b/utils/safe_fetch.py
@@ -483,8 +483,8 @@ class SafeFetcher:
             if response is not None:
                 try:
                     response.close()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("Failed to close HTTP response cleanly: %s", exc)
 
     def get(self, url: str, **kwargs) -> Optional[requests.Response]:
         """


### PR DESCRIPTION
## Title
  Fix Bandit findings (B324, B310, B110/B112, B105) across cache,
  OSINT, CLI, and health modules

  ## Summary
  This PR resolves multiple Bandit code-scanning alerts reported
  on branch `1.4.7`:

  - #677 (`core/cache.py`) weak MD5 usage
  - #680 (`core/osint/domain_intel.py`) `urlopen` scheme/host
  audit
  - #686 (`utils/safe_fetch.py`) try/except/pass
  - #685, #684 (`utils/cli_input.py`) try/except/pass
  - #683, #682 (`tools/page_reader.py`) try/except/pass and try/
  except/continue
  - #681 (`core/osint/sources/manager.py`) try/except/pass
  - #676 (`core/agent/agent.py`) try/except/continue
  - #679 (`core/health/widgets/status_card.py`) hardcoded
  password false positive
  - #678 (`core/health/result_parser.py`) hardcoded password
  false positive

  ## Changes
  ### 1) Cache hashing hardening (B324)
  - `core/cache.py`
  - Kept deterministic MD5 cache-key behavior, but marked non-
  security context:
    - `hashlib.md5(..., usedforsecurity=False)`

  ### 2) URL opening hardening (B310)
  - `core/osint/domain_intel.py`
  - Added strict pre-checks before `urlopen`:
    - allow only `http/https` schemes
    - allow only host `ip-api.com`
  - Added `# nosec B310` with rationale after explicit
  allowlisting.

  ### 3) Removed silent exception swallowing (B110/B112)
  - `tools/page_reader.py`
  - `utils/cli_input.py`
  - `utils/safe_fetch.py`
  logging.
  - Refactored `except ...: continue` patterns so `continue` is
  outside `except` blocks.

  - `core/health/result_parser.py`
  - Added targeted `# nosec B105` comments for non-secret numeric
  metrics (`pass_rate`).

  ## Validation
  - Ran syntax checks on all touched Python files with `python3
  - `f3d1afe` - Fix Bandit B324 in cache key hashing
  - `84ce536` - Fix Bandit findings across OSINT, CLI, and health
  modules