### PR TITLE
fix: patch langsmith file read & pydantic-settings symlink escape (#7…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ package = false
 override-dependencies = [
     "marshmallow==4.3.0",              # fix DoS CVE-2025-68480 (#22); GHSA-428g-f7cq-pgp5
     "protobuf>=7.34.1",                # fix JSON recursion depth bypass CVE-2026-0994 (#37); via chromadb
-    "langsmith>=0.7.33",               # fix SSRF CVE-2026-25528 (#38) + GHSA-rr7j-v2q5-chgv (#66); via langchain/langgraph
+    "langsmith>=0.8.18",               # fix SSRF CVE-2026-25528 (#38) + GHSA-rr7j-v2q5-chgv (#66) + TracingMiddleware arbitrary file read GHSA-f4xh-w4cj-qxq8 (#78); via langchain/langgraph
     "pillow>=12.2.0",                  # fix PSD OOB write CVE-2026-25990 (#40) + FITS bomb CVE-2026-40192 (#65); via sentence-transformers
     "langgraph-checkpoint>=4.0.2",     # fix BaseCache deserialization RCE (#42); via langchain/langgraph
     "orjson>=3.11.8",                  # fix nested-JSON recursion DoS (#44); via chromadb, langchain*, langgraph
@@ -124,6 +124,7 @@ override-dependencies = [
     "langchain-text-splitters>=1.1.2", # fix split_text_from_url SSRF redirect bypass GHSA-fv5p-p927-qmxr (#67)
     "transformers>=5.5.4",             # fix Trainer RCE via torch.load CVE-2026-1839 (#61); via sentence-transformers
     "lxml>=6.1.0",                     # fix XXE in iterparse/ETCompatXMLParser CVE-2026-41066 (#70); via ddgs (and overrides linkedin-api's <6.0.0 cap)
+    "pydantic-settings>=2.14.2",       # fix NestedSecretsSettingsSource symlink escape / secrets_dir_max_size bypass GHSA-4xgf-cpjx-pc3j (#79); via langchain/langsmith
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,13 @@ resolution-markers = [
 overrides = [
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langgraph-checkpoint", specifier = ">=4.0.2" },
-    { name = "langsmith", specifier = ">=0.7.33" },
+    { name = "langsmith", specifier = ">=0.8.18" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "marshmallow", specifier = "==4.3.0" },
     { name = "orjson", specifier = ">=3.11.8" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "protobuf", specifier = ">=7.34.1" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "transformers", specifier = ">=5.5.4" },
 ]
@@ -2040,7 +2041,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.7"
+version = "0.8.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2054,9 +2055,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/8a/9c4a27612f08b607fad56c1c093334d61d3e65d6b1783205118deb1da4bd/langsmith-0.8.7.tar.gz", hash = "sha256:1d0f2b4bcfbf26e9e37bf978dfe23e50d4c90bf1a0f26717879d56f941465a85", size = 4467388, upload-time = "2026-05-29T12:40:16.044Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d9/a6681aa9847bbbc5ec21abe20a5e233b94e5edcfe39624db607ac7e8ccb4/langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd", size = 4526988, upload-time = "2026-06-19T13:12:17.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/6e/a99e22455925eccb45aa2c5de1c4773309420bcc0ee1f8fec5bb20e70d9d/langsmith-0.8.7-py3-none-any.whl", hash = "sha256:bfc9bd3276c75201edbf85d12367502aed60752e2da720daee46dccb96f0c3cb", size = 402326, upload-time = "2026-05-29T12:40:13.623Z" },
+    { url = "https://files.pythonhosted.org/packages/03/70/0e0cc80a3b064c8d6c8d697c3125ed86e39d5a7393ec6dc8b07cb1cf13c4/langsmith-0.8.18-py3-none-any.whl", hash = "sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282", size = 508108, upload-time = "2026-06-19T13:12:15.348Z" },
 ]
 
 [[package]]
@@ -3520,16 +3521,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolve two Dependabot alerts on transitive deps via override-dependencies:
- langsmith >=0.8.18: TracingMiddleware arbitrary server-side file read (GHSA-f4xh-w4cj-qxq8, #78)
- pydantic-settings >=2.14.2: NestedSecretsSettingsSource symlink escape + secrets_dir_max_size bypass (GHSA-4xgf-cpjx-pc3j, #79)
